### PR TITLE
[ADD] 2615 python solution

### DIFF
--- a/solution/implementation/2615/main.py
+++ b/solution/implementation/2615/main.py
@@ -1,0 +1,44 @@
+# Authored by : seonjoo0885
+# Co-authored by : -
+# Link : http://boj.kr/a46811d50ced4e29ad20259b80a37a49
+
+import sys
+def input():
+    return sys.stdin.readline().rstrip()
+
+board = []
+for i in range(19):
+    board.append(list(map(int, input().split())))
+
+# → ↓ ↘ ↗
+dx = [0, 1, 1, -1]
+dy = [1, 0, 1, 1]
+
+for x in range(19):
+    for y in range(19):
+        if board[x][y] != 0:
+            focus = board[x][y]
+
+            for i in range(4):
+                cnt = 1
+                nx = x + dx[i]
+                ny = y + dy[i]
+
+                while 0 <= nx < 19 and 0 <= ny < 19 and board[nx][ny] == focus:
+                    cnt += 1
+                    
+                    if cnt == 5:
+                        # 육목 체크
+                        if 0 <= x - dx[i] < 19 and 0 <= y - dy[i] < 19 and board[x - dx[i]][y - dy[i]] == focus:
+                            break
+                        if 0 <= nx + dx[i] < 19 and 0 <= ny + dy[i] < 19 and board[nx + dx[i]][ny + dy[i]] == focus:
+                            break
+                        # 육목이 아니면 성공한거니까 종료
+                        print(focus)
+                        print(x + 1, y + 1)
+                        sys.exit(0)
+
+                    nx += dx[i]
+                    ny += dy[i]
+
+print(0)


### PR DESCRIPTION
승부가 결정되었을 경우, 연속된 다섯 개의 바둑알 중 가장 왼쪽에 있는 바둑알의 좌표를 출력해야 하기 때문에 탐색 방향을 왼쪽에서부터 뻗어나가는 → ↓ ↘ ↗로 설정합니다.

(0, 0)부터 (18, 18)까지 모든 좌표에서 바둑돌이 놓여있는 경우에만 for문을 4번 돌려 각 방향으로 5칸씩을 체크합니다.
5칸 연속으로 1 또는 2가 놓여있었을 경우 육목인 케이스를 걸러줘야 합니다.
- 첫번째 바둑돌보다 한 칸 이전의 바둑돌 체크
- 마지막 바둑돌보다 한 칸 이후의 바둑돌 체크

육목이 아니면 바둑돌의 종류와 위치를 출력하고 종료합니다. 모든 좌표를 탐색했는데도 종료하지 못했다면 승부가 결정되지 않은 것이므로 0을 출력합니다.